### PR TITLE
Correct README for http[s] redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Supports:
 * Red Hat 7
 
 ```
-curl -s setup.ius.io | bash
+curl -s https://setup.ius.io | bash
 ```


### PR DESCRIPTION
README.md previously did not specify a protocol, so curl defaulted to HTTP.  Looks like someone's added a redirect from HTTP to HTTPS at setup.ius.io:80 though, so the command in the README.md file was actually broken.  Specifying HTTPS in the curl command resolves the issue:
```
root@rhel7[~]# curl -s setup.ius.io | bash
bash: line 1: html: No such file or directory
bash: line 2: syntax error near unexpected token `<'
'ash: line 2: `<head><title>301 Moved Permanently</title></head>
root@rhel7[~]# curl -s setup.ius.io
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.6.3</center>
</body>
</html>
root@rhel7[~]# curl -I -k setup.ius.io
HTTP/1.1 301 Moved Permanently
Server: nginx/1.6.3
Date: Tue, 05 Jan 2016 16:43:02 GMT
Content-Type: text/html
Content-Length: 184
Connection: keep-alive
Location: https://setup.ius.io/

root@rhel7[~]# curl -s https://setup.ius.io/
#!/bin/bash
...
```